### PR TITLE
Automatically determine where to insert use statements, and fix bugs

### DIFF
--- a/lua/namespace/buffer.lua
+++ b/lua/namespace/buffer.lua
@@ -1,3 +1,4 @@
+local utils = require("namespace.utils")
 local M = {}
 
 M.get_bufnr = function(filename)
@@ -11,7 +12,8 @@ end
 
 M.add_to_buffer = function(line, bufnr)
     bufnr = bufnr or M.get_bufnr()
-    vim.api.nvim_buf_set_lines(bufnr, 3, 3, true, { line })
+    local insertion_point = utils.get_insertion_point()
+    vim.api.nvim_buf_set_lines(bufnr, insertion_point, insertion_point, true, { line })
     vim.api.nvim_echo({ { "Lines Added", 'Function' }, { ' ' .. 1 } }, true, {})
 end
 return M

--- a/lua/namespace/getClass.lua
+++ b/lua/namespace/getClass.lua
@@ -9,7 +9,8 @@ local M = {}
 
 M.add_to_buffer = function(line, bufnr)
     bufnr = bufnr or utils.get_bufnr()
-    vim.api.nvim_buf_set_lines(bufnr, 3, 3, true, { line })
+    local insertion_point = utils.get_insertion_point()
+    vim.api.nvim_buf_set_lines(bufnr, insertion_point, insertion_point, true, { line })
     vim.api.nvim_echo({ { "Lines Added", 'Function' }, { ' ' .. 1 } }, true, {})
 end
 

--- a/lua/namespace/getClasses.lua
+++ b/lua/namespace/getClasses.lua
@@ -98,7 +98,10 @@ M.get = function()
             if sr == nil then
                 vim.api.nvim_echo({ { "0 Lines Added", 'Function' }, { ' ' .. 0 } }, true, {})
             elseif #sr == 1 then
-                ccclss:insert(1, sr:unpack())
+                local line = sr:unpack()
+                line = line:gsub("%\\\\", "\\")
+                line = "use " .. line .. ";"
+                ccclss:insert(1, line)
             elseif #sr > 1 then
                 pop.popup(sr, bufnr)
             end
@@ -125,7 +128,8 @@ M.get = function()
     if #class >= 1 then
         local scls = { class:unpack() }
         table.sort(scls, function(a, b) return #a < #b end)
-        vim.api.nvim_buf_set_lines(bufnr, 3, 3, true, scls)
+        local insertion_point = utils.get_insertion_point(bufnr)
+        vim.api.nvim_buf_set_lines(bufnr, insertion_point, insertion_point, true, scls)
     end
 end
 

--- a/lua/namespace/utils.lua
+++ b/lua/namespace/utils.lua
@@ -52,6 +52,43 @@ M.class_filter = function(all, usedclss)
     return c
 end
 
+----------------------
+-- Get the line number to insert new use statements based on the current structure of the file
+----------------------
+M.get_insertion_point = function(bufnr)
+    bufnr = bufnr or M.get_bufnr()
+    local content = vim.api.nvim_buf_get_lines(bufnr, 0, vim.api.nvim_buf_line_count(bufnr), false)
 
+    -- default to line 3
+    local insertion_point = 3
+    local namespace_line_number = nil
+    local last_use_statement_line_number = nil
+
+
+    for i, line in ipairs(content) do
+        if line:find("^namespace") then
+            namespace_line_number = i
+        end
+
+        if line:find("^use") then
+            last_use_statement_line_number = i
+        end
+    end
+
+    if namespace_line_number then
+        if not last_use_statement_line_number then
+            -- insert an empty line after the namespace
+            vim.api.nvim_buf_set_lines(bufnr, namespace_line_number, namespace_line_number, true, { "" })
+        end
+        insertion_point = namespace_line_number + 1
+    end
+
+    if last_use_statement_line_number then
+        insertion_point = last_use_statement_line_number
+    end
+
+
+    return insertion_point
+end
 
 return M

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Neovim Php Namespace Resolver - tested on mac
 ## Requires
 
 -   pleanery.nvim
--   nvim-treesitter
+-   nvim-treesitter (`:TSInstall php`, `:TSInstall json`)
 -   brew install ripgrep
 
 ## Basic Usage


### PR DESCRIPTION
Originally the plugin was always inserting use statements on line 3 of the file, but that doesn't always work (at least for how I structure my PHP files).

I've updated it to determine the insertion point automatically based on the files contents. If there are existing use statements in the file, it will just append onto the end of the statements. If there's no existing use statements, but there is a namespace statement, it will add an empty line after the namespace statement and then add the use statements there.

If there are no use statements and no namespace statement, it will fallback to the default of inserting them onto line 3.

I also fixed the RSearch function. Originally it was returning a list of paths, now it returns a list of fully qualified namespaced class names so they can be used for inserting use statements.


The README has been updated to reflect that you also have to install treesitter plugins.